### PR TITLE
New versions of locust_plugins, TimescaleListener class can't understand

### DIFF
--- a/examples/timescale_listener_ex.py
+++ b/examples/timescale_listener_ex.py
@@ -38,7 +38,7 @@ class MyUser(HttpUser):
 
 @events.init.add_listener
 def on_locust_init(environment, **_kwargs):
-    listeners.Timescale(env=environment, testplan="timescale_listener_ex", target_env="myTestEnv")
+    listeners.Timescale(env=environment, testplan="timescale_listener_ex", profile_name="myTestEnv", description"myTestEnv example")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
New versions of locust_plugins, TimescaleListener class can't understand target_env parameter.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/locust/event.py", line
40, in fire
    handler(**kwargs)
  File "examples/timescale_listener_ex.py", line XX, in
on_locust_init
    listeners.Timescale(env=environment,
testplan="timescale_listener_ex", target_env="myTestEnv")
TypeError: __init__() got an unexpected keyword argument 'target_env'
```

Please, look `site-packages/locust_plugins/listener.py, line 50.`