### PR TITLE
Allow Control over Log Propagation to Parent Logger. Fixes #41

### DIFF
--- a/locust_plugins/appinsights_listener.py
+++ b/locust_plugins/appinsights_listener.py
@@ -5,7 +5,7 @@ from opencensus.ext.azure.log_exporter import AzureLogHandler
 
 
 class ApplicationInsights:
-    def __init__(self, env: locust.env.Environment, testplan="", instrumentation_key=""):
+    def __init__(self, env: locust.env.Environment, testplan="", instrumentation_key="", propagate_logs=True):
         self.testplan = testplan or "appinsightstestplan"
         self.env = env
         self.logger = logging.getLogger(__name__)
@@ -16,6 +16,7 @@ class ApplicationInsights:
             formated_key = "InstrumentationKey=" + str(os.getenv("APP_INSIGHTS_INSTRUMENTATION_KEY"))
 
         self.logger.addHandler(AzureLogHandler(connection_string=formated_key))
+        self.logger.propagate(propagate_logs)
 
         env.events.request_success.add_listener(self.request_success)
         env.events.request_failure.add_listener(self.request_failure)


### PR DESCRIPTION
This PR addresses #41 

An additional, optional, parameter to the ApplicationInsights constructor allows the user to control whether the AI logger propagates events to the parent logger.

The default is that is does (i.e. that `propagate_logs` is `True`) to maintain backward compat. By setting this param to `False` the AI events continue to be handled by the `AzureLogHandler`, but are not then propagated to the parent logger and streamed to the console.

If you'd like me to add any examples/update docs, please let me know. 

Happy to help, and thank you for these locust plugins! 