### PR TITLE
Fix missed columns in 'testrun' table schema (timescale_schema.sql)

### DIFF
--- a/locust_plugins/timescale_schema.sql
+++ b/locust_plugins/timescale_schema.sql
@@ -27,7 +27,9 @@ CREATE TABLE public.testrun (
     gitrepo character varying(40),
     rps_avg numeric,
     resp_time_avg numeric,
-    changeset_guid character varying(36)
+    changeset_guid character varying(36),
+    fail_ratio double precision,
+    requests integer
 );
 
 


### PR DESCRIPTION
After step-by-step execution of points from [example](https://github.com/SvenskaSpel/locust-plugins/blob/master/examples/timescale_listener_ex.py) when launching load tests, an error occurred due to a broken table schema