### PR TITLE
resize timescaledb gitrepo testrun column.

### DIFF
--- a/locust_plugins/timescale_schema.sql
+++ b/locust_plugins/timescale_schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE public.testrun (
     end_time timestamp with time zone,
     env character varying(10) NOT NULL,
     username character varying(64),
-    gitrepo character varying(40),
+    gitrepo character varying(120),
     rps_avg numeric,
     resp_time_avg numeric,
     changeset_guid character varying(36),


### PR DESCRIPTION
Sometimes when we're working with git repos inside a group the actual limit of 40 characters becomes small causing an insertion failure. It's normal when the company use `gitlab` and many subgroups of teams. Please consider this small change.