### PR TITLE
Add missing declarations and parenthesis

### DIFF
--- a/locust_plugins/transaction_manager.py
+++ b/locust_plugins/transaction_manager.py
@@ -19,6 +19,8 @@ class TransactionManager:
     when running in master/worker mode, all data is sent to the master during execution
     """
 
+    transactions_filename = ""
+    transactions_summary_filename = ""
     flush_size = 100
     field_delimiter = ","
     row_delimiter = "\n"
@@ -180,7 +182,7 @@ class TransactionManager:
                 headers = {}
                 headers["Content-type"] = "text/csv"
                 headers["Content-disposition"] = f"attachment;filename={cls.transactions_summary_filename}"
-                with StringIO as buffer:
+                with StringIO() as buffer:
                     writer = cls._create_csv_writer(buffer)
                     writer.writerows(cls._get_transactions_summary())
                     response = buffer.getvalue()


### PR DESCRIPTION
In an environment with the latest version of locust, transaction manager does not work, failing with the following message

```
  File "/home/serhiy/.local/lib/python3.8/site-packages/locust_plugins/transaction_manager.py", line 165, in _transactions_results_page
    headers["Content-disposition"] = f"attachment;filename={cls.transactions_filename}"
AttributeError: type object 'TransactionManager' has no attribute 'transactions_filename'
```

This PR should fix this  