### PR TITLE
Fix: use auto-generated client ID when creating MQTT client

### DIFF
--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -76,12 +76,14 @@ class MqttUser(User):
     transport = "tcp"
     ws_path = "/mqtt"
     tls_context = None
+    client_id = None
 
     def __init__(self, environment: Environment):
         super().__init__(environment)
         self.client: MqttClient = MqttClient(
             environment=self.environment,
             transport=self.transport,
+            client_id=self.client_id,
         )
 
         if self.tls_context:


### PR DESCRIPTION
Real easy to boost the number of bugs you fix when you're the one introducing them -- sorry! :-)

The MqttClient introduced in #62 auto-generates an MQTT client ID if it is not provided, but failed to pass this to the paho-mqtt.