### PR TITLE
Allow use of context manager with webdriver

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,3 +15,7 @@ disable=logging-not-lazy,logging-fstring-interpolation,missing-docstring,wrong-i
 [MASTER]
 ignore=locustio,examples
 extension-pkg-whitelist=lxml
+
+[SIMILARITIES]
+# Minimum lines number of a similarity - set high to avoid issues with examples/transaction*
+min-similarity-lines=25

--- a/examples/debug_ex_advanced.py
+++ b/examples/debug_ex_advanced.py
@@ -22,4 +22,4 @@ def on_locust_init(environment, **_kwargs):
 
 if __name__ == "__main__":
     MyUser.host = "http://example.com"
-    run_single_user(MyUser, include_time=True, include_length=True, init_listener=on_locust_init)
+    run_single_user(MyUser, include_time=True, include_length=True)

--- a/examples/reschedule_on_fail_ex.py
+++ b/examples/reschedule_on_fail_ex.py
@@ -21,4 +21,4 @@ def on_locust_init(environment, **_kwargs):
 
 
 if __name__ == "__main__":
-    run_single_user(MyUser, init_listener=on_locust_init)
+    run_single_user(MyUser)

--- a/examples/rest_ex.py
+++ b/examples/rest_ex.py
@@ -51,21 +51,25 @@ class MyUser(RestUser):
         with self.rest("GET", "http://example.com:42/", json={"foo": 1}) as resp:
             pass
 
+
 class RestUserThatLooksAtErrors(RestUser):
     abstract = True
+
     @contextmanager
-    def rest(self, method, url, headers={}, **kwargs) -> ResponseContextManager:
+    def rest(self, method, url, **kwargs) -> ResponseContextManager:
         extra_headers = {"my_header": "my_value"}
-        with super().rest(method, url, headers={**headers, **extra_headers}, **kwargs) as resp:
-            # 
+        with super().rest(method, url, headers=extra_headers, **kwargs) as resp:
+            #
             if "error" in resp.js and resp.js["error"] is not None:
-                resp.failure(resp.js["error"])
+                # pylint thinks this is a FASTUser, and not a ResponseContextManager
+                resp.failure(resp.js["error"])  # pylint: disable=E1101
             yield resp
+
 
 class MyOtherRestUser(RestUserThatLooksAtErrors):
     @task
     def t(self):
-        with self.rest("GET", "/") as resp:
+        with self.rest("GET", "/") as resp:  # pylint: disable=W0612
             pass
 
 

--- a/examples/rest_ex.py
+++ b/examples/rest_ex.py
@@ -40,15 +40,15 @@ class MyUser(RestUser):
                 pass
 
         # response isnt even json, but RestUser will already have been marked it as a failure, so we dont have to do it again
-        with self.rest("GET", "/", json={"foo": 1}) as resp:
+        with self.rest("GET", "/", json={"foo": 1}) as _resp:
             pass
 
         # 404
-        with self.rest("GET", "http://example.com/", json={"foo": 1}) as resp:
+        with self.rest("GET", "http://example.com/", json={"foo": 1}) as _resp:
             pass
 
         # connection closed
-        with self.rest("GET", "http://example.com:42/", json={"foo": 1}) as resp:
+        with self.rest("GET", "http://example.com:42/", json={"foo": 1}) as _resp:
             pass
 
 
@@ -71,7 +71,7 @@ class MyOtherRestUser(RestUserThatLooksAtErrors):
 
     @task
     def t(self):
-        with self.rest("GET", "/") as resp:  # pylint: disable=W0612
+        with self.rest("GET", "/") as _resp:
             pass
 
 

--- a/examples/rest_ex.py
+++ b/examples/rest_ex.py
@@ -59,14 +59,16 @@ class RestUserThatLooksAtErrors(RestUser):
     def rest(self, method, url, **kwargs) -> ResponseContextManager:
         extra_headers = {"my_header": "my_value"}
         with super().rest(method, url, headers=extra_headers, **kwargs) as resp:
-            #
-            if "error" in resp.js and resp.js["error"] is not None:
-                # pylint thinks this is a FASTUser, and not a ResponseContextManager
-                resp.failure(resp.js["error"])  # pylint: disable=E1101
+            resp: ResponseContextManager
+            if resp.js and "error" in resp.js and resp.js["error"] is not None:
+                resp.failure(resp.js["error"])
             yield resp
 
 
 class MyOtherRestUser(RestUserThatLooksAtErrors):
+    host = "https://postman-echo.com"
+    wait_time = constant(180)  # be nice to postman-echo.com, and dont run this at scale.
+
     @task
     def t(self):
         with self.rest("GET", "/") as resp:  # pylint: disable=W0612

--- a/examples/socketio_ex.py
+++ b/examples/socketio_ex.py
@@ -18,9 +18,6 @@ class MySocketIOUser(SocketIOUser):
         while not self.my_value:
             time.sleep(0.1)
 
-        # you can do http in the same taskset as well
-        self.client.get("/")
-
         # wait for additional pushes, while occasionally sending heartbeats, like a real client would
         self.sleep_with_heartbeat(10)
 

--- a/examples/webdriver_ex.py
+++ b/examples/webdriver_ex.py
@@ -106,6 +106,16 @@ class MyUser(WebdriverUser):
             wait = WebDriverWait(self.client, 5, poll_frequency=0.5)
             wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "body > div")))
 
+    @task
+    def example_with_context_manager(self):
+        with self.request(name="example_with_context_manager") as request:
+            request.client.get("https://example.com/")
+            title = request.client.find_element(By.CSS_SELECTOR, "body > div > h1")
+            if title.text == "Example Domain":
+                request.success()
+            else:
+                request.failure("Page title didn't match")
+
 
 @events.init.add_listener
 def on_locust_init(environment, **_kwargs):

--- a/examples/webdriver_ex.py
+++ b/examples/webdriver_ex.py
@@ -2,6 +2,9 @@
 # Download it from https://www.seleniumhq.org/download/ and run it by executing:
 # java -jar selenium-server-4.0.0-beta-4.jar standalone
 # Also, make sure you have installed chromedriver first. On macOS you would do: brew install --cask chromedriver
+#
+# You can also run selnium server via docker using the following example command:
+# docker run -e SE_NODE_SESSION_TIMEOUT=60 -e SE_NODE_MAX_SESSIONS=5 -p 4444:4444 -p 7900:7900 --shm-size="2g" --rm selenium/standalone-chrome:96.0
 import time
 from locust import task, constant, events
 from locust_plugins import run_single_user
@@ -9,6 +12,8 @@ from locust_plugins.users import WebdriverUser
 from locust_plugins.listeners import RescheduleTaskOnFail
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 
 class MyUser(WebdriverUser):
@@ -29,7 +34,7 @@ class MyUser(WebdriverUser):
     @task
     def my_task(self):
         self.clear()
-        self.client.start_time = time.monotonic()  # to measure the time from now to first find_element finishes
+        self.client.start_time = time.monotonic()  # to measure the time from now to first locust_find_element finishes
         scenario_start_time = self.client.start_time  # to measure the time for the whole scenario
         self.client.get("https://example.com/")
         self.client.add_cookie(
@@ -41,13 +46,15 @@ class MyUser(WebdriverUser):
             }
         )
         self.client.get("https://example.com/")
-        ssn_input = self.client.find_element(By.CSS_SELECTOR, "#ssn", name="ssn entry page ready")
+        ssn_input = self.client.locust_find_element(By.CSS_SELECTOR, "#ssn", name="ssn entry page ready")
         ssn_input.click()
         ssn_input.send_keys("199901010109")
         ssn_input.send_keys(Keys.RETURN)
         self.client.implicitly_wait(10)
-        self.client.find_element(By.XPATH, '//*[@id="last-login-time"]/div/div[4]/a/span', name="logged in").click()
-        self.client.find_element(
+        self.client.locust_find_element(
+            By.XPATH, '//*[@id="last-login-time"]/div/div[4]/a/span', name="logged in"
+        ).click()
+        self.client.locust_find_element(
             By.CSS_SELECTOR,
             "body > div.fixed-top-content.js-top-content-wrapper.balance-bar-ao-brand-small > div.balance-bar-account > span.balance-bar-account-item.balance-bar-left-border.pointer.js-balance-toggle.balance-bar-toggle > span",
             name="balance clickable",  # this is just client side so it will be really fast
@@ -61,6 +68,44 @@ class MyUser(WebdriverUser):
             exception=None,
         )
 
+    @task
+    def failure_with_context_manager(self):
+        # The context manager tracks all activities together under a single event with the time based on
+        # the entry into the with loop, and finishes when the exist occurs, or success/failure method is called.
+        # Don't call success/failure multiple times - create a new context or task if you need to track multiple events.
+        with self.request(name="failure_with_context_manager") as request:
+            request.client.get("https://example.com/")
+
+            # Leverate native webdriver features like Wait
+            wait = WebDriverWait(self.client, 5, poll_frequency=0.5)
+            # This will cause a timeout because #ssn does not exist on the example.com page.
+            wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "#ssn")))
+
+            # If success/failure is called automatically based on if an exception is raised from the content of the context.
+            # You can also manually trigger success/failure if needed.
+            # request.success()
+            # or
+            # request.failure(exception)
+
+    @task
+    def failure_with_context_manager2(self):
+        # Example of how a element not on the page generates a failure
+        with self.request(name="failure_with_context_manager2") as request:
+            request.client.get("https://example.com/")
+
+            # simple check for element presence -> raises no_such_element exception which is caught by the context manager.
+            request.client.find_element(By.CSS_SELECTOR, "body > div > div")
+
+    @task
+    def success_with_context_manager(self):
+        # Example of a successful lookup
+        with self.request(name="success_with_context_manager") as request:
+            request.client.get("https://example.com/")
+
+            # leverage native webdriver features like Wait
+            wait = WebDriverWait(self.client, 5, poll_frequency=0.5)
+            wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "body > div")))
+
 
 @events.init.add_listener
 def on_locust_init(environment, **_kwargs):
@@ -68,4 +113,4 @@ def on_locust_init(environment, **_kwargs):
 
 
 if __name__ == "__main__":
-    run_single_user(MyUser, init_listener=on_locust_init)
+    run_single_user(MyUser)

--- a/locust_plugins/users/webdriver.py
+++ b/locust_plugins/users/webdriver.py
@@ -201,9 +201,13 @@ class WebDriverResponseContextManager:
         """
         Report the response as successful
         Example::
-            with self.client.get("/does/not/exist", catch_response=True) as response:
-                if response.status_code == 404:
-                    response.success()
+            with self.request(name="helpful_name") as request:
+                request.client.get("https://example.com/")
+                title = request.client.find_element(By.CSS_SELECTOR, "body > div > h1")
+                if title.text == "Example Domain":
+                    request.success()
+                else:
+                    request.failure("Page title didn't match")
         """
         if not self._entered:
             raise LocustError(
@@ -218,9 +222,13 @@ class WebDriverResponseContextManager:
         if exc is anything other than a python exception (like a string) it will
         be wrapped inside a CatchResponseError.
         Example::
-            with self.client.get("/", catch_response=True) as response:
-                if response.content == b"":
-                    response.failure("No data")
+            with self.request(name="helpful_name") as request:
+                request.client.get("https://example.com/")
+                title = request.client.find_element(By.CSS_SELECTOR, "body > div > h1")
+                if title.text != "Example Domain":
+                    request.success()
+                else:
+                    request.failure("Page title didn't match")
         """
         if not self._entered:
             raise LocustError(

--- a/locust_plugins/users/webdriver.py
+++ b/locust_plugins/users/webdriver.py
@@ -2,8 +2,14 @@
 import subprocess
 import time
 from locust import User
+from locust.exception import CatchResponseError, LocustError
 from selenium import webdriver
-from selenium.common.exceptions import NoSuchElementException, WebDriverException, InvalidSessionIdException
+from selenium.common.exceptions import (
+    TimeoutException,
+    NoSuchElementException,
+    WebDriverException,
+    InvalidSessionIdException,
+)
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 import greenlet
@@ -53,7 +59,7 @@ class WebdriverClient(webdriver.Remote):
         #     ),
         # )
 
-    def find_element(
+    def locust_find_element(
         self, by=By.ID, value=None, name=None, prefix="", retry=0, context=None, fake_success=False
     ):  # pylint: disable=arguments-differ
         element = None
@@ -79,7 +85,7 @@ class WebdriverClient(webdriver.Remote):
 
         except Exception as e:
             if retry < 2:
-                return self.find_element(by=by, value=value, name=name, retry=retry + 1)
+                return self.locust_find_element(by=by, value=value, name=name, retry=retry + 1)
             total_time = (time.perf_counter() - self.start_time) * 1000
             error_message = e.args[0]
             try:
@@ -128,6 +134,104 @@ class WebdriverClient(webdriver.Remote):
         return element
 
 
+class WebDriverResponseContextManager:
+    """
+    A Response like class that also acts as a context manager that provides the ability to manually
+    control if the webdriver session request should be marked as successful or a failure in Locust's statistics
+    Use the two additional methods: :py:meth:`success <locust.clients.ResponseContextManager.success>` and
+    :py:meth:`failure <locust.clients.ResponseContextManager.failure>` to update the locust stats.
+
+    This class is based on Locust ResponseContextManager
+    """
+
+    _manual_result = None
+    _entered = False
+
+    def __init__(self, user, client, request_event, request_meta):
+        self.client = client
+        self.user = user
+        self._request_event = request_event
+        self.request_meta = request_meta
+
+    def __enter__(self):
+        self._entered = True
+        if not self.request_meta["start_time"]:
+            self.request_meta["start_time"] = time.perf_counter()
+
+        return self
+
+    def __exit__(self, exc, value, traceback):
+        # if the user has already manually marked this response as failure or success
+        # we can ignore the default behaviour of letting the response code determine the outcome
+        if self._manual_result is not None:
+            if self._manual_result is True:
+                self.request_meta["exception"] = None
+            elif isinstance(self._manual_result, Exception):
+                self.request_meta["exception"] = self._manual_result
+            self._report_request()
+            return exc is None
+
+        # no manual result fired - set stop time as current time
+        self.request_meta["response_time"] = (time.perf_counter() - self.request_meta["start_time"]) * 1000
+
+        if exc:
+            # Override the default rendering of exceptions to avoid printing complete stack traces.
+            if isinstance(value, TimeoutException):
+                self.request_meta["exception"] = "Timeout waiting for Webdriver:" + value.msg
+                self._report_request()
+            elif isinstance(value, WebDriverException):
+                self.request_meta["exception"] = "Webdriver Exception:" + value.msg
+                self._report_request()
+            else:
+                # we want other unknown exceptions to be raised
+                return False
+        else:
+            self._report_request()
+
+        return True
+
+    def _report_request(self):
+        # if URL is None, update with current url
+        if not self.request_meta["url"]:
+            self.request_meta["url"] = self.client.current_url
+
+        self._request_event.fire(**self.request_meta)
+
+    def success(self):
+        """
+        Report the response as successful
+        Example::
+            with self.client.get("/does/not/exist", catch_response=True) as response:
+                if response.status_code == 404:
+                    response.success()
+        """
+        if not self._entered:
+            raise LocustError(
+                "Tried to set status on a request that has not yet been made. Make sure you use a with-block, like this:\n\nwith self.client.request(..., catch_response=True) as response:\n    response.success()"
+            )
+        self._manual_result = True
+        self.request_meta["response_time"] = (time.perf_counter() - self.request_meta["start_time"]) * 1000
+
+    def failure(self, exc):
+        """
+        Report the response as a failure.
+        if exc is anything other than a python exception (like a string) it will
+        be wrapped inside a CatchResponseError.
+        Example::
+            with self.client.get("/", catch_response=True) as response:
+                if response.content == b"":
+                    response.failure("No data")
+        """
+        if not self._entered:
+            raise LocustError(
+                "Tried to set status on a request that has not yet been made. Make sure you use a with-block, like this:\n\nwith self.client.request(..., catch_response=True) as response:\n    response.failure(...)"
+            )
+        if not isinstance(exc, Exception):
+            exc = CatchResponseError(exc)
+        self._manual_result = exc
+        self.request_meta["response_time"] = (time.perf_counter() - self.request_meta["start_time"]) * 1000
+
+
 class WebdriverUser(User):
 
     abstract = True
@@ -144,6 +248,30 @@ class WebdriverUser(User):
 
         self.client = WebdriverClient(self)
         time.sleep(1)
+
+    def request(self, name, context=None) -> WebDriverResponseContextManager:
+        start_time = time.perf_counter()
+        total_time = (time.perf_counter() - start_time) * 1000
+
+        context = context or {}
+        if self.client.user:
+            context = {**self.client.user.context(), **context}
+
+        # store meta data that is used when reporting the request to locust's statistics
+        request_meta = {
+            "request_type": "Webdriver",
+            "response_time": total_time,
+            "response_length": 0,
+            "name": name,
+            "context": context,
+            "exception": None,
+            "start_time": start_time,
+            "url": None,
+        }
+
+        return WebDriverResponseContextManager(
+            user=self, client=self.client, request_event=self.environment.events.request, request_meta=request_meta
+        )
 
     def clear(self):
         for _ in range(3):

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     pytest
 commands =
     pylint --rcfile .pylintrc locust_plugins/
-    pylint --rcfile .pylintrc examples/
+    python -c 'from glob import glob; import subprocess; subprocess.check_call(["pylint", "--rcfile", ".pylintrc"] + glob("examples/*.py"))'
     pytest
     black --check locust_plugins/
     python3 examples/debug_ex.py

--- a/tusk.yaml
+++ b/tusk.yaml
@@ -18,7 +18,7 @@ tasks:
       - command:
           exec: |
             pylint --rcfile .pylintrc locust_plugins/
-            pylint --rcfile .pylintrc examples/
+            pylint --rcfile .pylintrc examples/*.py
 
   test:
     usage: runs the tox suite in the 3.9 environment


### PR DESCRIPTION
Rename the webdriver client to prevent overloading the standard selenium find_element method.
Adds a context manager that handles errors, and firing of events to locust

Resolves https://github.com/SvenskaSpel/locust-plugins/issues/68

Example test run output
```
❯ PYTHONPATH=. python examples/webdriver_ex.py

type	name                                              	resp_ms	exception	
Webdriver	failure_with_context_manager2                     	5215   	Exception('Webdriver Exception:no such element: Unable to locate element: {"method":"css selector","selector":"body > div > div"}\n  (Session info: chrome=96.0.4664.93)')	
Webdriver	failure_with_context_manager                      	5629   	Exception('Timeout waiting for Webdriver:')	
Webdriver	failure_with_context_manager2                     	5119   	Exception('Webdriver Exception:no such element: Unable to locate element: {"method":"css selector","selector":"body > div > div"}\n  (Session info: chrome=96.0.4664.93)')	
Webdriver	success_with_context_manager                      	106    	         	
Webdriver	failure_with_context_manager2                     	5126   	Exception('Webdriver Exception:no such element: Unable to locate element: {"method":"css selector","selector":"body > div > div"}\n  (Session info: chrome=96.0.4664.93)')	
find	ssn entry page ready                              	15327  	'no such element: {"method":"css selector","selector":"#ssn"} (waited 5.0s, chrome=96.0.4664.93)'	
```