### PR TITLE
gitrepo is too short to store most git repo

### DIFF
--- a/locust_plugins/dashboards/locust-timescale/timescale_schema.sql
+++ b/locust_plugins/dashboards/locust-timescale/timescale_schema.sql
@@ -170,7 +170,7 @@ CREATE TABLE public.testrun (
     end_time timestamp with time zone,
     env character varying(10) NOT NULL,
     username character varying(64),
-    gitrepo character varying(40),
+    gitrepo character varying(120),
     rps_avg numeric,
     resp_time_avg numeric,
     changeset_guid character varying(36),


### PR DESCRIPTION
This is actually failing your load test if your git remote url is longer than 40 characters