### PR TITLE
fixed run-id diff issue for timescale

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,7 @@ attr-rgx=[a-z0-9_]{1,30}$
 ignored-argument-names=_.*|^ignored_|^unused_|^kwargs|^environment
 
 [MESSAGES CONTROL]
-disable=logging-not-lazy,logging-fstring-interpolation,missing-docstring,wrong-import-position,wrong-import-order,too-few-public-methods,invalid-name,protected-access,logging-format-interpolation,dangerous-default-value,global-statement,too-many-locals,too-many-arguments,too-many-instance-attributes,blacklisted-name,attribute-defined-outside-init,broad-except,bare-except,consider-using-with,too-many-branches,unspecified-encoding,arguments-differ,C0330
+disable=logging-not-lazy,logging-fstring-interpolation,missing-docstring,wrong-import-position,wrong-import-order,too-few-public-methods,invalid-name,protected-access,logging-format-interpolation,dangerous-default-value,global-statement,too-many-locals,too-many-arguments,too-many-instance-attributes,blacklisted-name,attribute-defined-outside-init,broad-except,bare-except,consider-using-with,too-many-branches,unspecified-encoding,arguments-differ
 
 [MASTER]
 ignore=locustio,examples

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,7 @@ attr-rgx=[a-z0-9_]{1,30}$
 ignored-argument-names=_.*|^ignored_|^unused_|^kwargs|^environment
 
 [MESSAGES CONTROL]
-disable=logging-not-lazy,logging-fstring-interpolation,missing-docstring,wrong-import-position,wrong-import-order,too-few-public-methods,invalid-name,protected-access,logging-format-interpolation,dangerous-default-value,global-statement,too-many-locals,too-many-arguments,too-many-instance-attributes,blacklisted-name,attribute-defined-outside-init,broad-except,bare-except,consider-using-with,too-many-branches,unspecified-encoding,arguments-differ
+disable=logging-not-lazy,logging-fstring-interpolation,missing-docstring,wrong-import-position,wrong-import-order,too-few-public-methods,invalid-name,protected-access,logging-format-interpolation,dangerous-default-value,global-statement,too-many-locals,too-many-arguments,too-many-instance-attributes,blacklisted-name,attribute-defined-outside-init,broad-except,bare-except,consider-using-with,too-many-branches,unspecified-encoding,arguments-differ,C0330
 
 [MASTER]
 ignore=locustio,examples

--- a/locust_plugins/listeners.py
+++ b/locust_plugins/listeners.py
@@ -238,7 +238,18 @@ class Timescale:  # pylint: disable=R0902
             self._user_count_logger.kill()
         self.log_stop_test_run(exit_code)
 
-    def on_request(self, request_type, name, response_time, response_length, exception, context, start_time=None, url=None, **kwargs):
+    def on_request(
+        self,
+        request_type,
+        name,
+        response_time,
+        response_length,
+        exception,
+        context,
+        start_time=None,
+        url=None,
+        **kwargs,
+    ): # pylint: disable=C0330
         success = 0 if exception else 1
         if start_time:
             time = datetime.fromtimestamp(start_time, tz=timezone.utc)
@@ -385,7 +396,9 @@ class Print:
             f"\n{self.include_time}type\t{'name'.ljust(50)}\tresp_ms\t{self.include_length}exception\t{self.include_context}"
         )
 
-    def on_request(self, request_type, name, response_time, response_length, exception, context: dict, start_time=None, **kwargs):
+    def on_request(
+        self, request_type, name, response_time, response_length, exception, context: dict, start_time=None, **kwargs
+    ):
         if exception:
             if isinstance(exception, CatchResponseError):
                 e = str(exception)

--- a/locust_plugins/listeners.py
+++ b/locust_plugins/listeners.py
@@ -138,7 +138,7 @@ class Timescale:  # pylint: disable=R0902
         if (
             self.env.parsed_options.worker
             or self.env.parsed_options.master
-            or isinstance(environment.runner) == LocalRunner
+            or isinstance(environment.runner, LocalRunner)
         ):
             # swarm generates the run id for its master and workers
             if getattr(environment.parsed_options, "run_id", False):

--- a/locust_plugins/listeners.py
+++ b/locust_plugins/listeners.py
@@ -81,7 +81,7 @@ class Timescale:  # pylint: disable=R0902
             self.env.runner.register_message("get_run_id", self.set_run_id)
 
     def set_run_id(self, environment, msg, **kwargs):
-        logging.info(f'Received run id from master. Using this {datetime.strptime(msg.data, "%Y-%m-%d, %H:%M:%S.%f")}')
+        logging.debug(f'Received run id from master. Using this {datetime.strptime(msg.data, "%Y-%m-%d, %H:%M:%S.%f")}')
         self._run_id = datetime.strptime(msg.data, "%Y-%m-%d, %H:%M:%S.%f").astimezone(tz=timezone.utc)
 
     @contextmanager
@@ -146,15 +146,14 @@ class Timescale:  # pylint: disable=R0902
             elif hasattr(self, "_run_id"):
                 pass
             else:
-                logging.info(
+                logging.debug(
                     "You are running distributed, but without swarm. run_id:s in Timescale will not match exactly between load gens"
                 )
                 self._run_id = datetime.now(timezone.utc)
                 logging.info(f"Run id is {self._run_id}")
         else:
-            # non-swarm runs need to generate the run id here
             self._run_id = datetime.now(timezone.utc)
-            logging.info(f"Run id is {self._run_id}")
+            logging.debug(f"Run id is {self._run_id}")
         if not self.env.parsed_options.worker:
             logging.info(
                 f"Follow test run here: {self.env.parsed_options.grafana_url}&var-testplan={self._testplan}&from={int(self._run_id.timestamp()*1000)}&to=now"

--- a/locust_plugins/listeners.py
+++ b/locust_plugins/listeners.py
@@ -135,7 +135,11 @@ class Timescale:  # pylint: disable=R0902
             sys.exit(1)
         self.set_gitrepo()
 
-        if self.env.parsed_options.worker or self.env.parsed_options.master or isinstance(environment.runner) == LocalRunner:
+        if (
+            self.env.parsed_options.worker
+            or self.env.parsed_options.master
+            or isinstance(environment.runner) == LocalRunner
+        ):
             # swarm generates the run id for its master and workers
             if getattr(environment.parsed_options, "run_id", False):
                 self._run_id = parser.parse(environment.parsed_options.run_id)
@@ -249,7 +253,7 @@ class Timescale:  # pylint: disable=R0902
         start_time=None,
         url=None,
         **kwargs,
-    ): # pylint: disable=C0330
+    ):
         success = 0 if exception else 1
         if start_time:
             time = datetime.fromtimestamp(start_time, tz=timezone.utc)

--- a/locust_plugins/listeners.py
+++ b/locust_plugins/listeners.py
@@ -154,7 +154,7 @@ class Timescale:  # pylint: disable=R0902
                 f"Follow test run here: {self.env.parsed_options.grafana_url}&var-testplan={self._testplan}&from={int(self._run_id.timestamp()*1000)}&to=now"
             )
             if type(environment.runner) != LocalRunner:
-                for i, worker in enumerate(environment.runner.clients):
+                for _, worker in enumerate(environment.runner.clients):
                     msg = (
                         self._run_id.replace(tzinfo=timezone.utc)
                         .astimezone(tz=self._run_id.astimezone().tzinfo)
@@ -520,8 +520,8 @@ class RunOnUserError:
 
 
 def is_worker(env: locust.env.Environment):
-    return "--worker" in sys.argv or env.parsed_options.worker
+    return env.parsed_options.worker
 
 
 def is_master(env: locust.env.Environment):
-    return "--master" in sys.argv or env.parsed_options.master
+    return env.parsed_options.master


### PR DESCRIPTION
Updated logic for Timescale master and worker identification function. 
Added logic to sync run-id between master and worker. only in localrunner mode it works as well.

Tested below

- Ran a test in local runner
- Ran a test in master worker config
- Ran a test by giving run-id in config