### PR TITLE
Timescale/Dashboards: Use docker compose v2 syntax

### DIFF
--- a/bin/locust-compose
+++ b/bin/locust-compose
@@ -1,5 +1,4 @@
 #!/bin/bash
 module_location=$(python3 -c "import locust_plugins; print(locust_plugins.__path__[0])")
 set -x
-docker-compose -f $module_location/dashboards/docker-compose.yml "$@" || \
 docker compose -f $module_location/dashboards/docker-compose.yml "$@"

--- a/bin/locust-compose
+++ b/bin/locust-compose
@@ -1,4 +1,5 @@
 #!/bin/bash
 module_location=$(python3 -c "import locust_plugins; print(locust_plugins.__path__[0])")
 set -x
-docker-compose -f $module_location/dashboards/docker-compose.yml "$@"
+docker-compose -f $module_location/dashboards/docker-compose.yml "$@" || \
+docker compose -f $module_location/dashboards/docker-compose.yml "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
     grep -m 1 "Report: http://localhost:3000/d/qjIIww4Zz?&var-testplan=examples/rest_ex.py&from=" output.txt
     bash -ec "! grep -q Traceback output.txt"
     # check that there is at least one logging from today
-    bash -ec "docker exec dashboards_postgres_1 psql -U postgres -qtAc 'select id from testrun' | grep $(date +'%y-%m-%d')"
+    bash -ec "docker exec dashboards-postgres-1 psql -U postgres -qtAc 'select id from testrun' | grep $(date +'%y-%m-%d')"
     ; check that main dashboard exists
     curl --fail 'http://localhost:3000/api/dashboards/uid/qjIIww4Zz'
     ; run this if you want to ensure a clean slate


### PR DESCRIPTION
The script was modified to avoid related errors caused by the upgrade of docker-compose version. The specific issue is that, as mentioned in the [web page](https://docs.docker.com/compose/install/linux/), Compose V1 will no longer be supported.