### PR TITLE
README.md: Remove Print

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ locust --help
 ## Listeners 
 - Listen to events and log things
     - Timescale: Log and graph results using TimescaleDB and Grafana dashboards ([readme](locust_plugins/dashboards/), [source](locust_plugins/listeners.py))
-    - Print: Prints prints every request to standard out with response time etc ([source](locust_plugins/listeners.py))
     - Jmeter: Writes a jmeter-like output file ([example](examples/jmeter_listener_example.py), [source](locust_plugins/jmeter_listener.py))
     - ApplicationInsights: Writes the test logs to Azure Application Insights ([example](examples/appinsights_listener_ex.py), [source](locust_plugins/appinsights_listener.py))
     - RescheduleTaskOnFail / ExitOnFail / StopUserOnFail: Perform actions when a request fails ([source](locust_plugins/listeners.py))


### PR DESCRIPTION
It was removed in https://github.com/SvenskaSpel/locust-plugins/pull/138, since it's `locust.debug.PrintListener` now.

------

Thanks for sharing all those plugins, it's a great resource 👏 🥳 