### PR TITLE
Added locust-influxDB listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ locust --help
     - Jmeter: Writes a jmeter-like output file ([example](examples/jmeter_listener_example.py), [source](locust_plugins/jmeter_listener.py))
     - ApplicationInsights: Writes the test logs to Azure Application Insights ([example](examples/appinsights_listener_ex.py), [source](locust_plugins/appinsights_listener.py))
     - RescheduleTaskOnFail / ExitOnFail / StopUserOnFail: Perform actions when a request fails ([source](locust_plugins/listeners.py))
+- Other listenes:
+    - InfluxDB: Log, view and monitor test executions in Grafana using InfluxDB ([library](https://pypi.org/project/locust-influxdb-listener/), [example](https://github.com/pjcalvo/locust-influxdb-listener/tree/main/example))
 
 ## Users
 - New protocols ([source](locust_plugins/users/))


### PR DESCRIPTION
Hi, I would like our listener to be documented in your repository. I thought of adding the code to the repository as well, but 
- I really think I want to be able to control de release lifecycle of the listener 
- I don't want to have the users of the library download an entire repository when all they need is a simple library. 
- Finally my library has been actively used a lot lately and I don't want to tell the consumers to move to a new repo.

Let me know what you think.

