### PR TITLE
Cloudwatch plugin

### DIFF
--- a/examples/cloudwatch_listener_ex.py
+++ b/examples/cloudwatch_listener_ex.py
@@ -1,16 +1,11 @@
-import traceback
-import logging
-import sys
 from locust import main, events
 from locust_plugins.listeners.cloudwatch import CloudwatchAdapter, ServiceContext
-
+from locust_plugins import missing_extra
 
 try:
     import boto3
 except ModuleNotFoundError:
-    traceback.print_exc()
-    logging.error("boto3 is not installed by default, you need to install it using 'pip install boto3'")
-    sys.exit(1)
+    missing_extra("boto3", "boto3")
 
 
 @events.init.add_listener

--- a/examples/cloudwatch_listener_ex.py
+++ b/examples/cloudwatch_listener_ex.py
@@ -1,0 +1,30 @@
+import traceback
+import logging
+import sys
+from locust import main, events
+from locust_plugins.listeners.cloudwatch import CloudwatchAdapter, ServiceContext
+
+
+try:
+    import boto3
+except ModuleNotFoundError:
+    traceback.print_exc()
+    logging.error("boto3 is not installed by default, you need to install it using 'pip install boto3'")
+    sys.exit(1)
+
+
+@events.init.add_listener
+def on_locust_init(environment, **_kwargs):
+    CloudwatchAdapter(_cloudwatch(), environment, _service_context())
+
+
+def _cloudwatch():
+    return boto3.client("cloudwatch")
+
+
+def _service_context():
+    return ServiceContext("MyExampleService", "perf")
+
+
+if __name__ == "__main__":
+    main.main()

--- a/examples/cloudwatch_listener_ex.py
+++ b/examples/cloudwatch_listener_ex.py
@@ -1,7 +1,7 @@
 from locust import events
-from locust_plugins.listeners.cloudwatch import CloudwatchAdapter, ServiceContext
+from locust_plugins.listeners.cloudwatch import CloudwatchAdapter
 
 
 @events.init.add_listener
 def on_locust_init(environment, **_kwargs):
-    CloudwatchAdapter(environment, ServiceContext("MyExampleService", "perf"))
+    CloudwatchAdapter(environment, "MyExampleService", "perf")

--- a/examples/cloudwatch_listener_ex.py
+++ b/examples/cloudwatch_listener_ex.py
@@ -10,15 +10,7 @@ except ModuleNotFoundError:
 
 @events.init.add_listener
 def on_locust_init(environment, **_kwargs):
-    CloudwatchAdapter(_cloudwatch(), environment, _service_context())
-
-
-def _cloudwatch():
-    return boto3.client("cloudwatch")
-
-
-def _service_context():
-    return ServiceContext("MyExampleService", "perf")
+    CloudwatchAdapter(boto3.client("cloudwatch"), environment, ServiceContext("MyExampleService", "perf"))
 
 
 if __name__ == "__main__":

--- a/examples/cloudwatch_listener_ex.py
+++ b/examples/cloudwatch_listener_ex.py
@@ -1,17 +1,7 @@
-from locust import main, events
+from locust import events
 from locust_plugins.listeners.cloudwatch import CloudwatchAdapter, ServiceContext
-from locust_plugins import missing_extra
-
-try:
-    import boto3
-except ModuleNotFoundError:
-    missing_extra("boto3", "boto3")
 
 
 @events.init.add_listener
 def on_locust_init(environment, **_kwargs):
-    CloudwatchAdapter(boto3.client("cloudwatch"), environment, ServiceContext("MyExampleService", "perf"))
-
-
-if __name__ == "__main__":
-    main.main()
+    CloudwatchAdapter(environment, ServiceContext("MyExampleService", "perf"))

--- a/locust_plugins/listeners/cloudwatch.py
+++ b/locust_plugins/listeners/cloudwatch.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 from gevent import queue
 
@@ -10,12 +9,13 @@ class RequestResult:
 
     STATUS_FAILURE = "FAILURE"
 
-    def __init__(self, host, request_type, name, response_time, response_length, exception):
-        self.timestamp = datetime.datetime.utcnow()
+    def __init__(self, host, request_type, name, response_time, response_length, exception, start_time, url):
+        self.timestamp = start_time
         self.request_type = request_type
         self.name = name
         self.response_time = response_time
         self.host = host
+        self.url = url
 
         if exception:
             self.status = RequestResult.STATUS_FAILURE
@@ -140,9 +140,21 @@ class CloudwatchAdapter:
         self._post_to_cloudwatch(self._get_cw_metrics_batch(remaining_requests_metrics_size))
         log.info("Clean up on test stop...Done")
 
-    def on_request(self, request_type, name, response_time, response_length, response, context, exception, **kwargs):
+    def on_request(
+        self,
+        request_type,
+        name,
+        response_time,
+        response_length,
+        response,
+        context,
+        exception,
+        start_time,
+        url,
+        **kwargs,
+    ):
         request_result = RequestResult(
-            self.locust_env.host, request_type, name, response_time, response_length, exception
+            self.locust_env.host, request_type, name, response_time, response_length, exception, start_time, url
         )
         self.request_results_q.put(request_result)
 

--- a/locust_plugins/listeners/cloudwatch.py
+++ b/locust_plugins/listeners/cloudwatch.py
@@ -172,13 +172,13 @@ class CloudwatchAdapter:
         return f"{self._environment}/{self._service}/loadtests"
 
     def on_test_start(self, environment, **kwargs):
-        log.info("Begin setup")
+        log.debug("Begin setup")
 
     def on_test_stop(self, environment, **kwargs):
         remaining_requests_metrics_size = self.request_results_q.qsize()
-        log.info(f"Posting remaining metrics for {remaining_requests_metrics_size} requests")
+        log.debug(f"Posting remaining metrics for {remaining_requests_metrics_size} requests")
         self._post_to_cloudwatch(self._get_cw_metrics_batch(remaining_requests_metrics_size))
-        log.info("Clean up on test stop...Done")
+        log.debug("Clean up on test stop...Done")
 
     def on_request(
         self,

--- a/locust_plugins/listeners/cloudwatch.py
+++ b/locust_plugins/listeners/cloudwatch.py
@@ -1,0 +1,172 @@
+import datetime
+import logging
+from gevent import queue
+
+log = logging.getLogger(__name__)
+
+
+class RequestResult:
+    STATUS_SUCCESS = "SUCCESS"
+
+    STATUS_FAILURE = "FAILURE"
+
+    def __init__(self, host, request_type, name, response_time, response_length, exception):
+        self.timestamp = datetime.datetime.utcnow()
+        self.request_type = request_type
+        self.name = name
+        self.response_time = response_time
+        self.host = host
+
+        if exception:
+            self.status = RequestResult.STATUS_FAILURE
+            self.response_length = 0
+            self.exception = exception
+        else:
+            self.status = RequestResult.STATUS_SUCCESS
+            self.response_length = response_length
+            self.exception = ""
+
+    def get_all_metrics(self):
+        cw_metrics_for_request = [self.get_cw_metrics_response_time_record(), self.get_cw_metrics_count_record()]
+        if resp_size_rec := self.get_cw_metrics_response_size_record():
+            cw_metrics_for_request.append(resp_size_rec)
+        if fail_count_rec := self.get_cw_metrics_failure_count_record():
+            cw_metrics_for_request.append(fail_count_rec)
+        return cw_metrics_for_request
+
+    def get_cw_metrics_failure_count_record(self):
+        dimensions = self.get_metric_dimensions()
+        result = {}
+
+        if self.status == RequestResult.STATUS_FAILURE:
+            result = {
+                "MetricName": "FailureCount",
+                "Dimensions": dimensions,
+                "Timestamp": self.timestamp,
+                "Value": 1,
+                "Unit": "Count",
+            }
+
+        return result
+
+    def get_cw_metrics_response_size_record(self):
+        dimensions = self.get_metric_dimensions()
+
+        result = {}
+
+        if self.status == RequestResult.STATUS_SUCCESS:
+            result = {
+                "MetricName": "ResponseSize_Bytes",
+                "Dimensions": dimensions,
+                "Timestamp": self.timestamp,
+                "Value": self.response_length,
+                "Unit": "Bytes",
+            }
+
+        return result
+
+    def get_cw_metrics_response_time_record(self):
+        dimensions = self.get_metric_dimensions()
+        result = {
+            "MetricName": "ResponseTime_ms",
+            "Dimensions": dimensions,
+            "Timestamp": self.timestamp,
+            "Value": self.response_time,
+            "Unit": "Milliseconds",
+        }
+        return result
+
+    def get_cw_metrics_count_record(self):
+        dimensions = self.get_metric_dimensions()
+        result = {
+            "MetricName": "RequestCount",
+            "Dimensions": dimensions,
+            "Timestamp": self.timestamp,
+            "Value": 1,
+            "Unit": "Count",
+        }
+        return result
+
+    def get_metric_dimensions(self):
+        result = [
+            {"Name": "Request", "Value": self.name},
+            {"Name": "Method", "Value": self.request_type},
+            {"Name": "Host", "Value": self.host},
+        ]
+        return result
+
+    def api_id(self):
+        return f"{self.request_type}-{self.name}"
+
+
+class ServiceContext:
+    def __init__(self, service, environment="perf"):
+        self._service = service
+        self._environment = environment
+
+    def environment(self):
+        return self._environment
+
+    def service(self):
+        return self._service
+
+    def name(self):
+        return f"{self._environment}-{self._service}"
+
+    def metrics_namespace(self):
+        return f"{self._environment}/{self._service}/loadtests"
+
+
+class CloudwatchAdapter:
+    REQUESTS_BATCH_SIZE = 10
+    CLOUDWATCH_METRICS_BATCH_SIZE = 15  # Keeping it conservative not to breach the CW limit
+
+    def __init__(self, cloudwatch, locust_env, service_context):
+        self.cloudwatch = cloudwatch
+        self.locust_env = locust_env
+        self.service_context = service_context
+        self.request_results_q = queue.Queue(100)
+        events = self.locust_env.events
+        events.test_start.add_listener(self.on_test_start)
+        events.request.add_listener(self.on_request)
+        events.test_stop.add_listener(self.on_test_stop)
+
+    def on_test_start(self, environment, **kwargs):
+        log.info("Begin setup")
+
+    def on_test_stop(self, environment, **kwargs):
+        remaining_requests_metrics_size = self.request_results_q.qsize()
+        log.info(f"Posting remaining metrics for {remaining_requests_metrics_size} requests")
+        self._post_to_cloudwatch(self._get_cw_metrics_batch(remaining_requests_metrics_size))
+        log.info("Clean up on test stop...Done")
+
+    def on_request(self, request_type, name, response_time, response_length, response, context, exception, **kwargs):
+        request_result = RequestResult(
+            self.locust_env.host, request_type, name, response_time, response_length, exception
+        )
+        self.request_results_q.put(request_result)
+
+        if self.request_results_q.qsize() >= CloudwatchAdapter.REQUESTS_BATCH_SIZE:
+            self._post_to_cloudwatch(self._get_cw_metrics_batch())
+
+    def _get_cw_metrics_batch(self, request_batch_size=REQUESTS_BATCH_SIZE):
+        cw_metrics_batch = []
+        processed_request_count = 0
+        while processed_request_count < request_batch_size:
+            request_result = self.request_results_q.get()
+            cw_metrics_batch.extend(request_result.get_all_metrics())
+            processed_request_count += 1
+        return cw_metrics_batch
+
+    def _post_to_cloudwatch(self, cw_metrics_batch):
+        while len(cw_metrics_batch) > 0:
+            current_batch = cw_metrics_batch[: CloudwatchAdapter.CLOUDWATCH_METRICS_BATCH_SIZE]
+            cw_metrics_batch = cw_metrics_batch[CloudwatchAdapter.CLOUDWATCH_METRICS_BATCH_SIZE :]
+            if len(current_batch) > 0:
+                try:
+                    self.cloudwatch.put_metric_data(
+                        Namespace=self.service_context.metrics_namespace(), MetricData=current_batch
+                    )
+                    log.debug(f"Posted {len(current_batch)} metrics to cloudwatch")
+                except Exception as e:
+                    print(str(e))

--- a/locust_plugins/listeners/cloudwatch.py
+++ b/locust_plugins/listeners/cloudwatch.py
@@ -193,6 +193,7 @@ class CloudwatchAdapter:
         url,
         **kwargs,
     ):
+        # pylint: disable=unused-argument
         request_result = RequestResult(
             self.locust_env.host, request_type, name, response_time, response_length, exception, start_time, url
         )

--- a/locust_plugins/listeners/cloudwatch.py
+++ b/locust_plugins/listeners/cloudwatch.py
@@ -178,7 +178,7 @@ class CloudwatchAdapter:
         remaining_requests_metrics_size = self.request_results_q.qsize()
         log.debug(f"Posting remaining metrics for {remaining_requests_metrics_size} requests")
         self._post_to_cloudwatch(self._get_cw_metrics_batch(remaining_requests_metrics_size))
-        log.debug("Clean up on test stop...Done")
+        log.info("Clean up on test stop...Done")
 
     def on_request(
         self,

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ extras = {
     "mqtt": ["paho-mqtt>=1.5.0"],
     "appinsights": ["opencensus-ext-azure"],
     "resource": ["lxml"],
+    "boto3":["boto3"],
 }
 
 setup(

--- a/test/test_cloudwatch_plugin.py
+++ b/test/test_cloudwatch_plugin.py
@@ -19,7 +19,6 @@ class CloudwatchMock:
     def put_metric_data(self, Namespace, MetricData):
         self.call_count += 1
         self.metrics_dict[Namespace] = MetricData
-        
 
 
 cw = CloudwatchMock()
@@ -27,8 +26,6 @@ cw = CloudwatchMock()
 def on_locust_init(environment, **_kwargs):
     CloudwatchAdapter(environment, "MyExampleService", "perf", cw)
 
-
-events.init.add_listener(on_locust_init)
 
 class User(HttpUser):
     wait_time = between(1, 3)
@@ -38,10 +35,12 @@ class User(HttpUser):
     def my_task(self):
         self.client.get("/")
 
+
 class TestCloudwatch(TestCase):
     def test_basic_flow(self):
         # setup Environment and Runner
         env = Environment(user_classes=[User], events=events)
+        env.events.init.add_listener(on_locust_init)
         runner = env.create_local_runner()
         env.events.init.fire(environment=env, runner=runner)
 

--- a/test/test_cloudwatch_plugin.py
+++ b/test/test_cloudwatch_plugin.py
@@ -1,0 +1,64 @@
+import gevent
+from locust import events
+from locust import HttpUser, task, between
+from locust.env import Environment
+from locust.stats import stats_printer, stats_history
+from locust.log import setup_logging
+from locust_plugins.listeners.cloudwatch import CloudwatchAdapter, ServiceContext
+from locust_plugins import missing_extra
+import logging
+
+try:
+    from moto import mock_cloudwatch
+except ModuleNotFoundError:
+    missing_extra("moto", "moto")
+
+try:
+    import boto3
+except ModuleNotFoundError:
+    missing_extra("boto3", "boto3")
+
+setup_logging("INFO", None)
+
+def on_locust_init(environment, **_kwargs):
+    cw = _cloudwatch()
+    CloudwatchAdapter(cw, environment, _service_context())
+
+
+def _cloudwatch():
+    with mock_cloudwatch():
+        logging.info("Going to initialize cloudwatch")
+        cw = boto3.client("cloudwatch")
+        yield cw
+
+
+def _service_context():
+    return ServiceContext("MyExampleService", "perf")
+
+events.init.add_listener(on_locust_init)
+
+class User(HttpUser):
+    wait_time = between(1, 3)
+    host = "https://docs.locust.io"
+
+    @task
+    def my_task(self):
+        self.client.get("/")
+
+
+# setup Environment and Runner
+env = Environment(user_classes=[User], events=events)
+runner = env.create_local_runner()
+env.events.init.fire(environment=env, runner=runner)
+
+# start a greenlet that periodically outputs the current stats
+gevent.spawn(stats_printer(env.stats))
+
+# start a greenlet that save current stats to history
+gevent.spawn(stats_history, env.runner)
+env.runner.start(1, spawn_rate=10)
+
+# in 10 seconds stop the runner
+gevent.spawn_later(10, lambda: env.runner.quit())
+
+env.runner.greenlet.join()

--- a/test/test_cloudwatch_plugin.py
+++ b/test/test_cloudwatch_plugin.py
@@ -4,7 +4,7 @@ from locust import HttpUser, task, between
 from locust.env import Environment
 from locust.stats import stats_printer, stats_history
 from locust.log import setup_logging
-from locust_plugins.listeners.cloudwatch import CloudwatchAdapter, ServiceContext
+from locust_plugins.listeners.cloudwatch import CloudwatchAdapter
 from unittest import TestCase
 
 
@@ -25,11 +25,8 @@ class CloudwatchMock:
 cw = CloudwatchMock()
 
 def on_locust_init(environment, **_kwargs):
-    CloudwatchAdapter(cw, environment, _service_context())
+    CloudwatchAdapter(environment, "MyExampleService", "perf", cw)
 
-
-def _service_context():
-    return ServiceContext("MyExampleService", "perf")
 
 events.init.add_listener(on_locust_init)
 


### PR DESCRIPTION
A plugin which will allow locust metrics (request count, response time etc.) to be pushed to AWS cloudwatch (using boto3)