### PR TITLE
allowing more extensibility to customize the mqtt events logged in the database

### DIFF
--- a/examples/mqtt_custom_client_ex.py
+++ b/examples/mqtt_custom_client_ex.py
@@ -1,11 +1,7 @@
-import os
-import ssl
 import time
 import typing
 
 from locust import task, TaskSet
-from locust.env import Environment
-from locust.user.wait_time import between
 from locust_plugins.users.mqtt import MqttUser
 from locust_plugins.users.mqtt import MqttClient
 

--- a/examples/mqtt_custom_client_ex.py
+++ b/examples/mqtt_custom_client_ex.py
@@ -1,0 +1,49 @@
+import os
+import ssl
+import time
+import typing
+
+from locust import task, TaskSet
+from locust.env import Environment
+from locust.user.wait_time import between
+from locust_plugins.users.mqtt import MqttUser
+from locust_plugins.users.mqtt import MqttClient
+
+
+
+tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+tls_context.load_verify_locations(os.environ["LOCUST_MQTT_CAFILE"])
+
+# extend the MqttClient class with your own custom implementation
+class MyMqttClient(MqttClient):
+    def __init__(
+        self,
+        *args,
+        environment: Environment,
+        client_id: typing.Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(*args, environment, client_id, **kwargs)
+
+    # you can override the event name with your custom implementation
+    def _generate_event_name(self, event_type: str, qos: int, topic: str):
+        return f"mqtt:{event_type}:{qos}"
+
+
+class MyUser(MqttUser):
+    # override the client_cls with your custom MqttClient implementation
+    client_cls: typing.Type[MyMqttClient] = MyMqttClient
+
+    @task
+    class MyTasks(TaskSet):
+        # Sleep for a while to allow the client time to connect.
+        # This is probably not the most "correct" way to do this: a better method
+        # might be to add a gevent.event.Event to the MqttClient's on_connect
+        # callback and wait for that (with a timeout) here.
+        # However, this works well enough for the sake of an example.
+        def on_start(self):
+            time.sleep(5)
+
+        @task
+        def say_hello(self):
+            self.client.publish("hello/locust", b"hello world")

--- a/examples/mqtt_custom_client_ex.py
+++ b/examples/mqtt_custom_client_ex.py
@@ -10,20 +10,8 @@ from locust_plugins.users.mqtt import MqttUser
 from locust_plugins.users.mqtt import MqttClient
 
 
-
-tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
-tls_context.load_verify_locations(os.environ["LOCUST_MQTT_CAFILE"])
-
 # extend the MqttClient class with your own custom implementation
 class MyMqttClient(MqttClient):
-    def __init__(
-        self,
-        *args,
-        environment: Environment,
-        client_id: typing.Optional[str] = None,
-        **kwargs,
-    ):
-        super().__init__(*args, environment, client_id, **kwargs)
 
     # you can override the event name with your custom implementation
     def _generate_event_name(self, event_type: str, qos: int, topic: str):

--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -117,9 +117,8 @@ class MqttClient(mqtt.Client):
         self._publish_requests: dict[int, PublishedMessageContext] = {}
         self._subscribe_requests: dict[int, SubscribeContext] = {}
 
-    def _generate_event_name(self, event_type: str, qos: int, topic: str){
+    def _generate_event_name(self, event_type: str, qos: int, topic: str):
         return _generate_mqtt_event_name(event_type, qos, topic)
-    }
 
     def _on_publish_cb(
         self,


### PR DESCRIPTION
Added this to allow the option for users to customize the events logged in the database.
This would be done by extending the `MqttClient` class and overriding the `_generate_event_name` method.
For example when sending messages on a large variety of topics this generates a very fuzzy and hard-to-read set of charts in Grafana.
A more generic, simple view may be required.
Altering the queries in the Grafana dashboards to simplify the charts can be error-prone, performance downgrading, and will create maintenance overhead.
This solution allows users to alter the logged entry in the database for a more use-case-centric grouping.
I can provide more details of required - like a very simple dataset.
Thank you