### PR TITLE
pin paho-mqtt dependency to >=2.1.0 to keep the old callback API version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras = {
     "dashboards": ["psycogreen", "psycopg2-binary"],
     "kafka": ["confluent-kafka"],
     "mongo": ["pymongo"],
-    "mqtt": ["paho-mqtt>=1.5.0"],
+    "mqtt": ["paho-mqtt>=2.1.0"],
     "appinsights": ["opencensus-ext-azure"],
     "resource": ["lxml"],
     "boto3": ["boto3"],


### PR DESCRIPTION
As suggested in https://github.com/SvenskaSpel/locust-plugins/issues/180#issuecomment-2191549079