### PR TITLE
MQTT v5.0 support

### DIFF
--- a/examples/mqtt_custom_client_ex.py
+++ b/examples/mqtt_custom_client_ex.py
@@ -4,8 +4,7 @@ import typing
 from locust import task, TaskSet
 from locust_plugins.users.mqtt import MqttUser
 from locust_plugins.users.mqtt import MqttClient
-from paho.mqtt.client import Client
-from paho.mqtt.client import MQTTv5
+from paho.mqtt.client import MQTTv311
 
 
 # extend the MqttClient class with your own custom implementation

--- a/examples/mqtt_custom_client_ex.py
+++ b/examples/mqtt_custom_client_ex.py
@@ -4,10 +4,16 @@ import typing
 from locust import task, TaskSet
 from locust_plugins.users.mqtt import MqttUser
 from locust_plugins.users.mqtt import MqttClient
+from paho.mqtt.client import Client
+from paho.mqtt.client import MQTTv5
 
 
 # extend the MqttClient class with your own custom implementation
 class MyMqttClient(MqttClient):
+
+    # you can pass the desired MQTT protocol version from the initializer
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, protocol=MQTTv311, **kwargs)
 
     # you can override the event name with your custom implementation
     def _generate_event_name(self, event_type: str, qos: int, topic: str):

--- a/examples/mqtt_custom_client_ex.py
+++ b/examples/mqtt_custom_client_ex.py
@@ -4,7 +4,6 @@ import typing
 from locust import task, TaskSet
 from locust_plugins.users.mqtt import MqttUser
 from locust_plugins.users.mqtt import MqttClient
-from paho.mqtt.client import MQTTv311
 
 
 # extend the MqttClient class with your own custom implementation

--- a/examples/mqtt_custom_client_ex.py
+++ b/examples/mqtt_custom_client_ex.py
@@ -9,11 +9,6 @@ from paho.mqtt.client import MQTTv311
 
 # extend the MqttClient class with your own custom implementation
 class MyMqttClient(MqttClient):
-
-    # you can pass the desired MQTT protocol version from the initializer
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, protocol=MQTTv311, **kwargs)
-
     # you can override the event name with your custom implementation
     def _generate_event_name(self, event_type: str, qos: int, topic: str):
         return f"mqtt:{event_type}:{qos}"

--- a/examples/mqtt_ex.py
+++ b/examples/mqtt_ex.py
@@ -24,11 +24,6 @@ class MyUser(MqttUser):
     # 10-100 messages per second.
     wait_time = between(0.01, 0.1)
 
-    # you can pass the desired MQTT protocol version from the initializer
-    # useful if you need to use MQTTv5
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, protocol=MQTTv311, **kwargs)
-
     @task
     class MyTasks(TaskSet):
         # Sleep for a while to allow the client time to connect.

--- a/examples/mqtt_ex.py
+++ b/examples/mqtt_ex.py
@@ -2,6 +2,7 @@ import os
 import ssl
 import time
 
+from paho.mqtt.client import MQTTv311
 from locust import task, TaskSet
 from locust.user.wait_time import between
 from locust_plugins.users.mqtt import MqttUser
@@ -22,6 +23,11 @@ class MyUser(MqttUser):
     # We'll probably want to throttle our publishing a bit: let's limit it to
     # 10-100 messages per second.
     wait_time = between(0.01, 0.1)
+
+    # you can pass the desired MQTT protocol version from the initializer
+    # useful if you need to use MQTTv5
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, protocol=MQTTv311, **kwargs)
 
     @task
     class MyTasks(TaskSet):

--- a/examples/mqtt_ex.py
+++ b/examples/mqtt_ex.py
@@ -2,11 +2,9 @@ import os
 import ssl
 import time
 
-from paho.mqtt.client import MQTTv311
 from locust import task, TaskSet
 from locust.user.wait_time import between
 from locust_plugins.users.mqtt import MqttUser
-
 
 tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
 tls_context.load_verify_locations(os.environ["LOCUST_MQTT_CAFILE"])
@@ -23,6 +21,9 @@ class MyUser(MqttUser):
     # We'll probably want to throttle our publishing a bit: let's limit it to
     # 10-100 messages per second.
     wait_time = between(0.01, 0.1)
+
+    # Uncomment below if you need to set MQTTv5
+    # protocol = paho.mqtt.client.MQTTv5
 
     @task
     class MyTasks(TaskSet):

--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -404,13 +404,12 @@ class MqttUser(User):
     client_id = None
     username = None
     password = None
+    protocol = mqtt.MQTTv311
 
     def __init__(self, environment: Environment):
         super().__init__(environment)
         self.client: MqttClient = self.client_cls(
-            environment=self.environment,
-            transport=self.transport,
-            client_id=self.client_id,
+            environment=self.environment, transport=self.transport, client_id=self.client_id, protocol=self.protocol
         )
 
         if self.tls_context:

--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -215,23 +215,6 @@ class MqttClient(mqtt.Client):
                     },
                 )
 
-    def _on_disconnect_cb_v3x(
-        self,
-        client: mqtt.Client,
-        userdata: typing.Any,
-        rc: int,
-    ):
-        return _on_disconnect_cb(self, client, userdata, rc)
-
-    def _on_disconnect_cb_v5(
-        self,
-        client: mqtt.Client,
-        userdata: typing.Any,
-        reasoncode: ReasonCode,
-        properties: properties
-    ):
-        return _on_disconnect_cb(self, client, userdata, reasoncode)
-
     def _on_disconnect_cb(
         self,
         client: mqtt.Client,
@@ -261,24 +244,22 @@ class MqttClient(mqtt.Client):
                 },
             )
 
-    def _on_connect_cb_v3x(
+    def _on_disconnect_cb_v3x(
         self,
         client: mqtt.Client,
         userdata: typing.Any,
-        flags: dict[str, int],
         rc: int,
     ):
-        return _on_connect_cb(self, client, userdata, flags, rc)
+        return _on_disconnect_cb(self, client, userdata, rc)
 
-    def _on_connect_cb_v5(
+    def _on_disconnect_cb_v5(
         self,
         client: mqtt.Client,
         userdata: typing.Any,
-        flags: dict[str, int],
         reasoncode: ReasonCode,
         properties: properties
     ):
-        return _on_connect_cb(self, client, userdata, flags, reasoncode)
+        return _on_disconnect_cb(self, client, userdata, reasoncode)
 
     def _on_connect_cb(
         self,
@@ -309,6 +290,25 @@ class MqttClient(mqtt.Client):
                     "client_id": self.client_id,
                 },
             )
+
+    def _on_connect_cb_v3x(
+        self,
+        client: mqtt.Client,
+        userdata: typing.Any,
+        flags: dict[str, int],
+        rc: int,
+    ):
+        return _on_connect_cb(self, client, userdata, flags, rc)
+
+    def _on_connect_cb_v5(
+        self,
+        client: mqtt.Client,
+        userdata: typing.Any,
+        flags: dict[str, int],
+        reasoncode: ReasonCode,
+        properties: properties
+    ):
+        return _on_connect_cb(self, client, userdata, flags, reasoncode)
 
     def publish(
         self,

--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -256,6 +256,7 @@ class MqttClient(mqtt.Client):
     ):
         return self._on_disconnect_cb(client, userdata, rc)
 
+    # pylint: disable=unused-argument
     def _on_disconnect_cb_v5(
         self,
         client: mqtt.Client,
@@ -304,6 +305,7 @@ class MqttClient(mqtt.Client):
     ):
         return self._on_connect_cb(client, userdata, flags, rc)
 
+    # pylint: disable=unused-argument
     def _on_connect_cb_v5(
         self,
         client: mqtt.Client,

--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -76,7 +76,6 @@ class SubscribeContext(typing.NamedTuple):
 
 
 class MqttClient(mqtt.Client):
-
     def __init__(
         self,
         *args,

--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -76,12 +76,13 @@ class SubscribeContext(typing.NamedTuple):
 
 
 class MqttClient(mqtt.Client):
+
     def __init__(
         self,
         *args,
         environment: Environment,
         client_id: typing.Optional[str] = None,
-        protocol: MQTTProtocolVersion = MQTTProtocolVersion.MQTTv311,
+        protocol: MQTTProtocolVersion = mqtt.MQTTv311,
         **kwargs,
     ):
         """Initializes a paho.mqtt.Client for use in Locust swarms.
@@ -93,6 +94,8 @@ class MqttClient(mqtt.Client):
             environment: the Locust environment with which to associate events.
             client_id: the MQTT Client ID to use in connecting to the broker.
                 If not set, one will be randomly generated.
+            protocol: the MQTT protocol version. 
+                defaults to MQTT v3.11.
         """
         # If a client ID is not provided, this class will randomly generate an ID
         # of the form: `locust-[0-9a-zA-Z]{16}` (i.e., `locust-` followed by 16
@@ -116,7 +119,7 @@ class MqttClient(mqtt.Client):
         self.on_publish = self._on_publish_cb
         self.on_subscribe = self._on_subscribe_cb
 
-        if (self.protocol == MQTTProtocolVersion.MQTTv5):
+        if self.protocol == mqtt.MQTTv5:
             self.on_disconnect = self._on_disconnect_cb_v5
             self.on_connect = self._on_connect_cb_v5
         else:

--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -257,7 +257,11 @@ class MqttClient(mqtt.Client):
 
     # pylint: disable=unused-argument
     def _on_disconnect_cb_v5(
-        self, client: mqtt.Client, userdata: typing.Any, reasoncode: ReasonCode, properties: Properties
+        self,
+        client: mqtt.Client,
+        userdata: typing.Any,
+        reasoncode: ReasonCode,
+        properties: Properties,
     ):
         return self._on_disconnect_cb(client, userdata, reasoncode)
 

--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -115,6 +115,7 @@ class MqttClient(mqtt.Client):
 
         self.on_publish = self._on_publish_cb
         self.on_subscribe = self._on_subscribe_cb
+
         if (self.protocol == MQTTProtocolVersion.MQTTv5):
             self.on_disconnect = self._on_disconnect_cb_v5
             self.on_connect = self._on_connect_cb_v5
@@ -250,16 +251,16 @@ class MqttClient(mqtt.Client):
         userdata: typing.Any,
         rc: int,
     ):
-        return _on_disconnect_cb(self, client, userdata, rc)
+        return self._on_disconnect_cb(client, userdata, rc)
 
     def _on_disconnect_cb_v5(
         self,
         client: mqtt.Client,
         userdata: typing.Any,
         reasoncode: ReasonCode,
-        properties: properties
+        properties: Properties
     ):
-        return _on_disconnect_cb(self, client, userdata, reasoncode)
+        return self._on_disconnect_cb(client, userdata, reasoncode)
 
     def _on_connect_cb(
         self,
@@ -298,7 +299,7 @@ class MqttClient(mqtt.Client):
         flags: dict[str, int],
         rc: int,
     ):
-        return _on_connect_cb(self, client, userdata, flags, rc)
+        return self._on_connect_cb(client, userdata, flags, rc)
 
     def _on_connect_cb_v5(
         self,
@@ -306,9 +307,9 @@ class MqttClient(mqtt.Client):
         userdata: typing.Any,
         flags: dict[str, int],
         reasoncode: ReasonCode,
-        properties: properties
+        properties: Properties
     ):
-        return _on_connect_cb(self, client, userdata, flags, reasoncode)
+        return self._on_connect_cb(client, userdata, flags, reasoncode)
 
     def publish(
         self,

--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -14,8 +14,10 @@ except ModuleNotFoundError:
     missing_extra("paho", "mqtt")
 
 if typing.TYPE_CHECKING:
+    from paho.mqtt.enums import MQTTProtocolVersion
     from paho.mqtt.client import MQTTMessageInfo
     from paho.mqtt.properties import Properties
+    from paho.mqtt.reasoncodes import ReasonCode
     from paho.mqtt.subscribeoptions import SubscribeOptions
 
 
@@ -79,6 +81,7 @@ class MqttClient(mqtt.Client):
         *args,
         environment: Environment,
         client_id: typing.Optional[str] = None,
+        protocol: MQTTProtocolVersion = MQTTProtocolVersion.MQTTv311,
         **kwargs,
     ):
         """Initializes a paho.mqtt.Client for use in Locust swarms.
@@ -107,12 +110,18 @@ class MqttClient(mqtt.Client):
         else:
             self.client_id = client_id
 
-        super().__init__(*args, client_id=self.client_id, **kwargs)
+        super().__init__(*args, client_id=self.client_id, protocol=protocol, **kwargs)
         self.environment = environment
+
         self.on_publish = self._on_publish_cb
         self.on_subscribe = self._on_subscribe_cb
-        self.on_disconnect = self._on_disconnect_cb
-        self.on_connect = self._on_connect_cb
+        if (self.protocol == MQTTProtocolVersion.MQTTv5):
+            self.on_disconnect = self._on_disconnect_cb_v5
+            self.on_connect = self._on_connect_cb_v5
+        else:
+            self.on_disconnect = self._on_disconnect_cb_v3x
+            self.on_connect = self._on_connect_cb_v3x
+
 
         self._publish_requests: dict[int, PublishedMessageContext] = {}
         self._subscribe_requests: dict[int, SubscribeContext] = {}
@@ -206,6 +215,23 @@ class MqttClient(mqtt.Client):
                     },
                 )
 
+    def _on_disconnect_cb_v3x(
+        self,
+        client: mqtt.Client,
+        userdata: typing.Any,
+        rc: int,
+    ):
+        return _on_disconnect_cb(self, client, userdata, rc)
+
+    def _on_disconnect_cb_v5(
+        self,
+        client: mqtt.Client,
+        userdata: typing.Any,
+        reasoncode: ReasonCode,
+        properties: properties
+    ):
+        return _on_disconnect_cb(self, client, userdata, reasoncode)
+
     def _on_disconnect_cb(
         self,
         client: mqtt.Client,
@@ -234,6 +260,25 @@ class MqttClient(mqtt.Client):
                     "client_id": self.client_id,
                 },
             )
+
+    def _on_connect_cb_v3x(
+        self,
+        client: mqtt.Client,
+        userdata: typing.Any,
+        flags: dict[str, int],
+        rc: int,
+    ):
+        return _on_connect_cb(self, client, userdata, flags, rc)
+
+    def _on_connect_cb_v5(
+        self,
+        client: mqtt.Client,
+        userdata: typing.Any,
+        flags: dict[str, int],
+        reasoncode: ReasonCode,
+        properties: properties
+    ):
+        return _on_connect_cb(self, client, userdata, flags, reasoncode)
 
     def _on_connect_cb(
         self,

--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -94,7 +94,7 @@ class MqttClient(mqtt.Client):
             environment: the Locust environment with which to associate events.
             client_id: the MQTT Client ID to use in connecting to the broker.
                 If not set, one will be randomly generated.
-            protocol: the MQTT protocol version. 
+            protocol: the MQTT protocol version.
                 defaults to MQTT v3.11.
         """
         # If a client ID is not provided, this class will randomly generate an ID
@@ -125,7 +125,6 @@ class MqttClient(mqtt.Client):
         else:
             self.on_disconnect = self._on_disconnect_cb_v3x
             self.on_connect = self._on_connect_cb_v3x
-
 
         self._publish_requests: dict[int, PublishedMessageContext] = {}
         self._subscribe_requests: dict[int, SubscribeContext] = {}
@@ -258,11 +257,7 @@ class MqttClient(mqtt.Client):
 
     # pylint: disable=unused-argument
     def _on_disconnect_cb_v5(
-        self,
-        client: mqtt.Client,
-        userdata: typing.Any,
-        reasoncode: ReasonCode,
-        properties: Properties
+        self, client: mqtt.Client, userdata: typing.Any, reasoncode: ReasonCode, properties: Properties
     ):
         return self._on_disconnect_cb(client, userdata, reasoncode)
 
@@ -312,7 +307,7 @@ class MqttClient(mqtt.Client):
         userdata: typing.Any,
         flags: dict[str, int],
         reasoncode: ReasonCode,
-        properties: Properties
+        properties: Properties,
     ):
         return self._on_connect_cb(client, userdata, flags, reasoncode)
 


### PR DESCRIPTION
Added different callback signatures in the `MqttClient` for

- on_connect
- on_disconnect

to support MQTT v5.0

As per the comments in the paho mqtt client:

```
        """The callback called when the broker reponds to our connection request.

        Expected signature for callback API version 2::

            connect_callback(client, userdata, connect_flags, reason_code, properties)

        Expected signature for callback API version 1 change with MQTT protocol version:
            * For MQTT v3.1 and v3.1.1 it's::

                connect_callback(client, userdata, flags, rc)

            * For MQTT v5.0 it's::

                connect_callback(client, userdata, flags, reason_code, properties)


        :param Client client: the client instance for this callback
        :param userdata: the private user data as set in Client() or user_data_set()
        :param ConnectFlags connect_flags: the flags for this connection
        :param ReasonCode reason_code: the connection reason code received from the broken.
                       In MQTT v5.0 it's the reason code defined by the standard.
                       In MQTT v3, we convert return code to a reason code, see
                       `convert_connack_rc_to_reason_code()`.
                       `ReasonCode` may be compared to integer.
        :param Properties properties: the MQTT v5.0 properties received from the broker.
                       For MQTT v3.1 and v3.1.1 properties is not provided and an empty Properties
                       object is always used.
        :param dict flags: response flags sent by the broker
        :param int rc: the connection result, should have a value of `ConnackCode`
"""
```

I'm not sure if anything can be done with the `properties` param passed in the callbacks.
Let me know if any changes are required.
Thanks!