### PR TITLE
MqttClient does not have the protocol property

### DIFF
--- a/locust_plugins/users/mqtt.py
+++ b/locust_plugins/users/mqtt.py
@@ -118,7 +118,7 @@ class MqttClient(mqtt.Client):
         self.on_publish = self._on_publish_cb
         self.on_subscribe = self._on_subscribe_cb
 
-        if self.protocol == mqtt.MQTTv5:
+        if protocol == mqtt.MQTTv5:
             self.on_disconnect = self._on_disconnect_cb_v5
             self.on_connect = self._on_connect_cb_v5
         else:


### PR DESCRIPTION
I introduced an issue in my PR yesterday.
The `MqttClient` does not have the `protocol` property.
It is passed as a parameter.
Sorry about this.