### PR TITLE
add the option to add config when using kafka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ env
 _version.py
 examples/screenshot_*
 output.txt
+.idea

--- a/examples/kafka_ex.py
+++ b/examples/kafka_ex.py
@@ -5,6 +5,7 @@ import os
 
 class MyUser(KafkaUser):
     bootstrap_servers = os.environ["LOCUST_KAFKA_SERVERS"]
+    configs = {"compression.type": "gzip"}
 
     @task
     def t(self):

--- a/locust_plugins/users/kafka.py
+++ b/locust_plugins/users/kafka.py
@@ -37,7 +37,7 @@ def _on_delivery(environment, identifier, response_length, start_time, start_per
 
 
 class KafkaClient:
-    def __init__(self, *, environment, bootstrap_servers, configs=[]):
+    def __init__(self, *, environment, bootstrap_servers, configs=None):
         self.environment = environment
         self.producer = Producer({"bootstrap.servers": bootstrap_servers}, **configs)
 

--- a/locust_plugins/users/kafka.py
+++ b/locust_plugins/users/kafka.py
@@ -13,10 +13,12 @@ class KafkaUser(User):
     abstract = True
     # overload these values in your subclass
     bootstrap_servers: str = None  # type: ignore
+    configs: dict[str, str | int] = None
 
     def __init__(self, environment):
         super().__init__(environment)
-        self.client: KafkaClient = KafkaClient(environment=environment, bootstrap_servers=self.bootstrap_servers)
+        self.client: KafkaClient = KafkaClient(environment=environment, bootstrap_servers=self.bootstrap_servers,
+                                               configs=self.configs)
 
     def on_stop(self):
         self.client.producer.flush(5)
@@ -35,9 +37,9 @@ def _on_delivery(environment, identifier, response_length, start_time, start_per
 
 
 class KafkaClient:
-    def __init__(self, *, environment, bootstrap_servers):
+    def __init__(self, *, environment, bootstrap_servers, configs=[]):
         self.environment = environment
-        self.producer = Producer({"bootstrap.servers": bootstrap_servers})
+        self.producer = Producer({"bootstrap.servers": bootstrap_servers}, **configs)
 
     def send(self, topic: str, value: bytes, key=None, response_length_override=None, name=None, context={}):
         start_perf_counter = time.perf_counter()


### PR DESCRIPTION
I added the option to add config when using kafka - useful if you want to set specific compression or enable authentication mechanism to enable bigger throughput when load/stress testing