### PR TITLE
Fix: Allow Alphanumeric and Underscore Characters in Socket.IO Event Names

### DIFF
--- a/locust_plugins/users/socketio.py
+++ b/locust_plugins/users/socketio.py
@@ -94,7 +94,7 @@ class SocketIOUser(User):
                 name = "2 heartbeat"
             else:
                 # hoping this is a subscribe type message, try to detect name
-                m = re.search(r'(\d*)\["([a-z]*)"', body)
+                m = re.search(r'(\d*)\["([\w]*)"', body)
                 assert m is not None
                 code = m.group(1)
                 action = m.group(2)

--- a/locust_plugins/users/socketio.py
+++ b/locust_plugins/users/socketio.py
@@ -94,7 +94,7 @@ class SocketIOUser(User):
                 name = "2 heartbeat"
             else:
                 # hoping this is a subscribe type message, try to detect name
-                m = re.search(r'(\d*)\["([\w]*)"', body)
+                m = re.search(r'(\d*)\["([\w]+)"', body)
                 assert m is not None
                 code = m.group(1)
                 action = m.group(2)


### PR DESCRIPTION
## Description:
This PR modifies the regular expression used to extract Socket.IO event names to include alphanumeric characters and underscores by using \w.

Previously, the regex only matched lowercase alphabetic characters ([a-z]), which caused issues when event names contained underscores (e.g., "message_sent"). 

Using \w expands support to:
> 1. Lowercase and uppercase letters
> 2. Digits
> 3. Underscores ( _ )
> 

## Changes Made:
Updated regex from:

```python
r'(\d*)\["([a-z]*)"'
```
to

```python
r'(\d*)\["(\w+)"'
```


## Why This is Needed:
Our Socket.IO event names follow snake_case naming, which includes underscores. Without this change, events like "message_sent"" caused assertion failures during load testing with Locust.

## Impact:
Prevents errors for valid Socket.IO events containing underscores or digits.

Improves compatibility and robustness of WebSocket load testing scripts.

## Issue
Fixed this issue #220 
